### PR TITLE
5-add-get-authtutor-applications-endpoint-with-filters-for-limit-and-…

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -4,6 +4,7 @@ import { AuthService } from "../services/auth.service";
 const authService = new AuthService();
 
 export class AuthController {
+  // 🔹 Admin Login
   async adminLogin(req: FastifyRequest, reply: FastifyReply) {
     try {
       const { username, password } = req.body as any;
@@ -14,6 +15,7 @@ export class AuthController {
     }
   }
 
+  // 🔹 Parent Signup
   async parentSignup(req: FastifyRequest, reply: FastifyReply) {
     try {
       const user = await authService.signupParent(req.body as any);
@@ -23,6 +25,7 @@ export class AuthController {
     }
   }
 
+  // 🔹 Parent Login
   async parentLogin(req: FastifyRequest, reply: FastifyReply) {
     try {
       const { email, password } = req.body as any;
@@ -33,6 +36,7 @@ export class AuthController {
     }
   }
 
+  // 🔹 Tutor Signup
   async tutorSignup(req: FastifyRequest, reply: FastifyReply) {
     try {
       const user = await authService.signupTutor(req.body as any);
@@ -42,6 +46,7 @@ export class AuthController {
     }
   }
 
+  // 🔹 Tutor Login
   async tutorLogin(req: FastifyRequest, reply: FastifyReply) {
     try {
       const { email, password } = req.body as any;
@@ -49,6 +54,38 @@ export class AuthController {
       return reply.send(result);
     } catch (err: any) {
       return reply.status(400).send({ error: err.message });
+    }
+  }
+
+  // 🔹 Get Tutor Applications (Admin only)
+  async getTutorApplications(req: FastifyRequest, reply: FastifyReply) {
+    try {
+      const user = (req as any).user;
+      if (!user) {
+        return reply.status(401).send({ error: "Unauthorized" });
+      }
+
+      if (user.role !== "admin") {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
+
+      const { status, limit } = req.query as { status?: string; limit?: string };
+      const limitValue = limit ? parseInt(limit, 10) : 5;
+
+      const validStatuses = ["pending", "approved", "rejected"];
+      if (status && !validStatuses.includes(status)) {
+        return reply.status(400).send({ error: "Invalid status value" });
+      }
+
+      if (isNaN(limitValue) || limitValue <= 0) {
+        return reply.status(400).send({ error: "Invalid limit value" });
+      }
+
+      const result = await authService.getTutorApplications(status, limitValue);
+      return reply.send(result);
+    } catch (err: any) {
+      console.error("getTutorApplications error:", err);
+      return reply.status(500).send({ error: "Internal Server Error" });
     }
   }
 }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -84,4 +84,37 @@ export class AuthService {
     const token = signJwt({ id: user._id, role: user.role });
     return { token, user };
   }
+
+
+  async getTutorApplications(status?: string, limit: number = 5) {
+    const validStatuses = ["pending", "approved", "rejected"];
+    if (status && !validStatuses.includes(status)) {
+      throw new Error("Invalid status");
+    }
+
+    const limitValue = Number(limit) || 5;
+    if (!Number.isInteger(limitValue) || limitValue <= 0) {
+      throw new Error("Invalid limit");
+    }
+
+    const query: any = { role: "tutor" };
+    if (status) query.status = status;
+
+    const tutors = await User.find(query)
+      .sort({ createdAt: -1 }) // latest first
+      .limit(limitValue)
+      .select("fullName email status createdAt")
+      .lean();
+
+    return tutors.map((t: any) => ({
+      name: t.fullName,
+      email: t.email,
+      status: t.status,
+      appliedDate:
+        t.createdAt instanceof Date
+          ? t.createdAt.toISOString()
+          : new Date(t.createdAt).toISOString()
+    }));
+  }
+
 }


### PR DESCRIPTION
Implemented a new GET /auth/tutor-applications endpoint to allow admins to view recent tutor applications.
The endpoint supports filtering by status (pending, approved, rejected) and limiting results using the limit query parameter.
Results are sorted by latest application date.