### PR TITLE
8-add-get-parenttutors-endpoint-for-tutor-search-with-filters

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import fastify from "fastify";
 import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import authRoutes from "./routes/auth.routes";
+import parentRoutes from "./routes/parent.routes";
 
 const app = fastify({ logger: true });
 
@@ -40,6 +41,7 @@ async function buildApp() {
 
   // Routes
   app.register(authRoutes, { prefix: "/api/v1" });
+  app.register(parentRoutes, { prefix: "/api/v1" });
 
   return app;
 }

--- a/src/controllers/parent.controller.ts
+++ b/src/controllers/parent.controller.ts
@@ -1,0 +1,16 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+import { ParentService } from "../services/parent.service";
+
+const parentService = new ParentService();
+
+export class ParentController {
+  async getTutors(req: FastifyRequest, reply: FastifyReply) {
+    try {
+      const tutors = await parentService.searchTutors(req.query);
+      return reply.send(tutors);
+    } catch (err: any) {
+      console.error("Error fetching tutors:", err);
+      return reply.status(500).send({ error: "Internal Server Error" });
+    }
+  }
+}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -2,6 +2,8 @@ import { Schema, model, Document } from "mongoose";
 
 export type UserRole = "admin" | "parent" | "tutor";
 export type TutorStatus = "pending" | "phone_verified" | "approved" | "rejected";
+export type TeachingMode = "online" | "offline" | "hybrid";
+export type Availability = "weekdays" | "weekends" | "flexible";
 
 export interface IUser extends Document {
   role: UserRole;
@@ -21,6 +23,12 @@ export interface IUser extends Document {
   college?: string;
   yearsOfExperience?: number;
   status?: TutorStatus; // only for tutors
+
+  price?: number; // per month / per hour (decide one unit)
+  teachingMode?: TeachingMode;
+  availability?: Availability;
+  rating?: number; // 0-5
+  testimonial?: string;
 
   createdAt?: Date;
   updatedAt?: Date;
@@ -67,12 +75,25 @@ const UserSchema = new Schema<IUser>(
       type: String,
       enum: ["pending", "phone_verified", "approved", "rejected"],
       default: "pending"
-    }
+    },
+
+    price: { type: Number, default: 0 }, // numeric price
+    teachingMode: {
+      type: String,
+      enum: ["online", "offline", "hybrid"]
+    },
+    availability: {
+      type: String,
+      enum: ["weekdays", "weekends", "flexible"]
+    },
+    rating: { type: Number, default: 0 }, // average rating
+    testimonial: { type: String, default: "" }
+
   },
   { timestamps: true }
 );
 
-// 🔒 Role-based validation
+//  Role-based validation
 UserSchema.pre("validate", function (next) {
   if (this.role === "admin") {
     if (!this.username) return next(new Error("Admin must have a username"));
@@ -102,5 +123,10 @@ UserSchema.pre("validate", function (next) {
 
   next();
 });
+
+// Indexes for faster filtering
+UserSchema.index({ subjects: 1 });
+UserSchema.index({ price: 1 });
+UserSchema.index({ rating: -1 });
 
 export default model<IUser>("User", UserSchema);

--- a/src/routes/parent.routes.ts
+++ b/src/routes/parent.routes.ts
@@ -1,0 +1,8 @@
+import { FastifyInstance } from "fastify";
+import { ParentController } from "../controllers/parent.controller";
+
+const parentController = new ParentController();
+
+export default async function parentRoutes(app: FastifyInstance) {
+  app.get("/parent/tutors", (req, reply) => parentController.getTutors(req, reply));
+}

--- a/src/services/parent.service.ts
+++ b/src/services/parent.service.ts
@@ -1,0 +1,46 @@
+import User from "../models/User";
+
+export class ParentService {
+  async searchTutors(filters: any) {
+    const query: any = { role: "tutor" };
+
+    // Apply filters only if they exist
+    if (filters.subject) {
+      query.subjects = { $regex: new RegExp(filters.subject, "i") };
+    }
+
+    if (filters.teachingMode) {
+      query.teachingMode = filters.teachingMode;
+    }
+
+    if (filters.minPrice || filters.maxPrice) {
+      query.price = {};
+      if (filters.minPrice) query.price.$gte = Number(filters.minPrice);
+      if (filters.maxPrice) query.price.$lte = Number(filters.maxPrice);
+    }
+
+    if (filters.minExperience) {
+      query.yearsOfExperience = { $gte: Number(filters.minExperience) };
+    }
+
+    if (filters.availability) {
+      query.availability = filters.availability;
+    }
+
+    if (filters.minRating) {
+      query.rating = { $gte: Number(filters.minRating) };
+    }
+
+    console.log("Final Query:", query);
+
+    // Execute query
+    const tutors = await User.find(query)
+      .sort({ rating: -1 }) // sort by rating desc
+      .select(
+        "fullName email subjects teachingMode price yearsOfExperience availability rating testimonial"
+      )
+      .lean();
+
+    return tutors;
+  }
+}


### PR DESCRIPTION
Added new API endpoint /parent/tutors to allow parents to search tutors using multiple filters such as subject, teaching mode, price, experience, availability, and rating. Results are sorted by rating in descending order by default.