### PR TITLE
9-add-get-parentrequests-api-for-fetching-latest-and-all-tutor-requests

### DIFF
--- a/src/controllers/parent.controller.ts
+++ b/src/controllers/parent.controller.ts
@@ -13,4 +13,22 @@ export class ParentController {
       return reply.status(500).send({ error: "Internal Server Error" });
     }
   }
+
+  //Admin panel
+  async getParentRequests(req: FastifyRequest, reply: FastifyReply) {
+    try {
+      // ensure admin access is enforced in route preHandler
+      const { type, status, subject, limit } = req.query as any;
+
+      const result = await parentService.getParentRequests({ type, status, subject, limit });
+      return reply.send(result);
+    } catch (err: any) {
+      console.error("getParentRequests error:", err);
+      // return 400 for validation errors
+      if (err.message && (err.message.includes("Invalid") || err.message.includes("allowed"))) {
+        return reply.status(400).send({ error: err.message });
+      }
+      return reply.status(500).send({ error: "Internal Server Error" });
+    }
+  }
 }

--- a/src/models/ParentRequest.ts
+++ b/src/models/ParentRequest.ts
@@ -6,6 +6,7 @@ export interface IParentRequest extends Document {
   scheduling: string[];
   location: string;
   urgency: "within_24_hours" | "within_3_days" | "within_a_week";
+  status?: "pending" | "assigned" | "completed" | "cancelled";
   createdAt?: Date;
 }
 
@@ -19,9 +20,18 @@ const ParentRequestSchema = new Schema<IParentRequest>(
       type: String,
       enum: ["within_24_hours", "within_3_days", "within_a_week"],
       required: true
+    },
+    status: {
+      type: String,
+      enum: ["pending", "assigned", "completed", "cancelled"],
+      default: "pending"
     }
   },
   { timestamps: true }
 );
+
+ParentRequestSchema.index({ status: 1 });
+ParentRequestSchema.index({ academicNeeds: 1 });
+ParentRequestSchema.index({ createdAt: -1 });
 
 export default model<IParentRequest>("ParentRequest", ParentRequestSchema);

--- a/src/routes/parent.routes.ts
+++ b/src/routes/parent.routes.ts
@@ -1,8 +1,50 @@
 import { FastifyInstance } from "fastify";
 import { ParentController } from "../controllers/parent.controller";
+import { authMiddleware, roleMiddleware } from "../middlewares/auth";
 
 const parentController = new ParentController();
 
 export default async function parentRoutes(app: FastifyInstance) {
   app.get("/parent/tutors", (req, reply) => parentController.getTutors(req, reply));
+
+  // Admin: GET /parent/requests
+  app.get(
+    "/parent/requests",
+    {
+      preHandler: [authMiddleware, roleMiddleware(["admin"])],
+      schema: {
+        tags: ["Admin"],
+        summary: "Fetch parent-tutor requests (latest or all with filters)",
+        querystring: {
+          type: "object",
+          properties: {
+            type: { type: "string", enum: ["latest", "all"], default: "latest" },
+            status: { type: "string", enum: ["pending", "assigned", "completed", "cancelled"] },
+            subject: { type: "string" },
+            limit: { type: "integer", minimum: 1, default: 5 }
+          }
+        },
+        response: {
+          200: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "string" },
+                parentId: { type: "string" },
+                parent: { type: "object", nullable: true },
+                academicNeeds: { type: "array", items: { type: "string" } },
+                scheduling: { type: "array", items: { type: "string" } },
+                location: { type: "string" },
+                urgency: { type: "string" },
+                status: { type: "string" },
+                createdAt: { type: "string", format: "date-time" }
+              }
+            }
+          }
+        }
+      }
+    },
+    (req, reply) => parentController.getParentRequests(req, reply)
+  );
 }


### PR DESCRIPTION
Added GET /parent/requests endpoint for admin

- Allows admin to view parent-tutor requests.
- Supports two modes:
  • type=latest → fetch latest N requests (default 5)
  • type=all → fetch all requests with optional filters
- Added filters for status, subject, and limit.
- Updated ParentRequest model with status field.
- Secured route with admin-only access.
- Integrated Swagger documentation for API testing.