### PR TITLE
15-add-post-tutorcreate-quiz-endpoint

### DIFF
--- a/src/models/Quiz.ts
+++ b/src/models/Quiz.ts
@@ -1,0 +1,44 @@
+import mongoose, { Schema, Document, Types } from "mongoose";
+
+export interface IQuestion {
+  question: string;
+  options: string[];
+  correct_answer: string;
+}
+
+export interface IQuiz extends Document {
+  title: string;
+  subject: string;
+  class_grade: string;
+  description?: string;
+  questions: IQuestion[];
+  created_by: Types.ObjectId;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const QuestionSchema = new Schema<IQuestion>(
+  {
+    question: { type: String, required: true },
+    options: { type: [String], required: true },
+    correct_answer: { type: String, required: true }
+  },
+  { _id: false }
+);
+
+const QuizSchema = new Schema<IQuiz>(
+  {
+    title: { type: String, required: true },
+    subject: { type: String, required: true },
+    class_grade: { type: String, required: true },
+    description: { type: String, default: "" },
+    questions: { type: [QuestionSchema], required: true },
+    created_by: { type: Schema.Types.ObjectId, ref: "User", required: true }
+  },
+  { timestamps: true }
+);
+
+// indexes if needed
+QuizSchema.index({ created_by: 1, subject: 1 });
+
+export default mongoose.model<IQuiz>("Quiz", QuizSchema);

--- a/src/routes/tutor.routes.ts
+++ b/src/routes/tutor.routes.ts
@@ -28,4 +28,50 @@ export default async function tutorRoutes(app: FastifyInstance) {
     },
     (req, reply) => tutorController.createAssignment(req, reply)
   );
+
+  // quiz
+  app.post(
+    "/tutor/create-quiz",
+    {
+      preHandler: [authMiddleware, roleMiddleware(["tutor"])],
+      schema: {
+        tags: ["Tutor"],
+        summary: "Create a new quiz (JSON)",
+        consumes: ["application/json"],
+        body: {
+          type: "object",
+          required: ["title", "subject", "class_grade", "questions"],
+          properties: {
+            title: { type: "string" },
+            subject: { type: "string" },
+            class_grade: { type: "string" },
+            description: { type: "string" },
+            questions: {
+              type: "array",
+              items: {
+                type: "object",
+                required: ["question", "options", "correct_answer"],
+                properties: {
+                  question: { type: "string" },
+                  options: { type: "array", items: { type: "string" } },
+                  correct_answer: { type: "string" }
+                }
+              }
+            }
+          }
+        },
+        response: {
+          201: {
+            type: "object",
+            properties: {
+              message: { type: "string" },
+              quiz: { type: "object" }
+            }
+          }
+        }
+      }
+    },
+    (req, reply) => tutorController.createQuiz(req, reply)
+  );
+  
 }

--- a/src/services/tutor.service.ts
+++ b/src/services/tutor.service.ts
@@ -1,7 +1,7 @@
 import Assignment from "../models/Assignment";
+import Quiz from "../models/Quiz";
 
 export class TutorService {
-  // other tutor related methods...
 
   async createAssignment(payload: {
     title: string;
@@ -28,5 +28,33 @@ export class TutorService {
     });
 
     return assignment;
+  }
+
+
+  // Quiz
+  async createQuiz(payload: {
+    title: string;
+    subject: string;
+    class_grade: string;
+    description?: string;
+    questions: { question: string; options: string[]; correct_answer: string }[];
+    created_by: string;
+  }) {
+    // Basic validation at service level (controller does main checks)
+    if (!Array.isArray(payload.questions) || payload.questions.length === 0) {
+      throw new Error("Questions must be a non-empty array");
+    }
+
+    // Save
+    const quiz = await Quiz.create({
+      title: payload.title,
+      subject: payload.subject,
+      class_grade: payload.class_grade,
+      description: payload.description || "",
+      questions: payload.questions,
+      created_by: payload.created_by
+    });
+
+    return quiz;
   }
 }


### PR DESCRIPTION
Add POST /tutor/create-quiz endpoint

- New Quiz model (Quiz + Question sub-schema)
- TutorService.createQuiz() to save quizzes
- TutorController.createQuiz() to validate and handle requests
- Route /api/v1/tutor/create-quiz protected by auth and tutor role
- Input validation
- Returns created quiz summary
- Tests scaffolded for success/failure cases