### PR TITLE
25-upload-study-material

### DIFF
--- a/src/models/StudyMaterial.ts
+++ b/src/models/StudyMaterial.ts
@@ -1,0 +1,45 @@
+import { Schema, model, Document, Types } from "mongoose";
+
+export interface IFileMeta {
+  filename: string;
+  url: string;
+  size?: number;
+  mimetype?: string;
+}
+
+export interface IStudyMaterial extends Document {
+  material_title: string;
+  subject: string;
+  class_grade: string;
+  description?: string;
+  files: IFileMeta[];
+  share_with_all: boolean;
+  created_by: Types.ObjectId;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const FileSchema = new Schema<IFileMeta>(
+  {
+    filename: { type: String, required: true },
+    url: { type: String, required: true },
+    size: { type: Number },
+    mimetype: { type: String }
+  },
+  { _id: false }
+);
+
+const StudyMaterialSchema = new Schema<IStudyMaterial>(
+  {
+    material_title: { type: String, required: true },
+    subject: { type: String, required: true },
+    class_grade: { type: String, required: true },
+    description: { type: String, default: "" },
+    files: { type: [FileSchema], default: [] },
+    share_with_all: { type: Boolean, default: false },
+    created_by: { type: Schema.Types.ObjectId, ref: "User", required: true }
+  },
+  { timestamps: true }
+);
+
+export default model<IStudyMaterial>("StudyMaterial", StudyMaterialSchema);

--- a/src/routes/tutor.routes.ts
+++ b/src/routes/tutor.routes.ts
@@ -201,4 +201,32 @@ export default async function tutorRoutes(app: FastifyInstance) {
     },
     (req, reply) => tutorController.deleteQuiz(req, reply)
   );
+
+
+  //upload study material
+  app.post(
+    "/tutor/upload-study-material",
+    {
+      preHandler: [authMiddleware, roleMiddleware(["tutor"])],
+      schema: {
+        tags: ["Tutor"],
+        summary: "Upload study material (multipart/form-data)",
+        consumes: ["multipart/form-data"],
+        body: { type: "object" }, // multipart - validation done in controller
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              success: { type: "boolean" },
+              message: { type: "string" },
+              data: { type: "object" }
+            }
+          },
+          400: { type: "object" },
+          403: { type: "object" }
+        }
+      }
+    },
+    (req, reply) => tutorController.uploadStudyMaterial(req, reply)
+  );
 }


### PR DESCRIPTION
Added an endpoint that allows tutors to upload study materials (PDF, DOC, images, or videos) categorized by subject and grade. Tutors can optionally add a description and choose to share the material with all students by default.

Includes:
POST /tutor/upload-study-material API
File upload support using multipart/form-data
Validation for required fields and file types
Returns uploaded file details on success