### PR TITLE
26-add-student

### DIFF
--- a/src/controllers/parent.controller.ts
+++ b/src/controllers/parent.controller.ts
@@ -14,6 +14,53 @@ export class ParentController {
     }
   }
 
+  // Add student
+  async addStudent(req: FastifyRequest, reply: FastifyReply) {
+    try {
+      const body = req.body as any;
+      const { full_name, class_grade } = body;
+
+      if (!full_name || !class_grade) {
+        return reply.status(400).send({ success: false, message: "Full name and class_grade are required." });
+      }
+
+      const cg = String(class_grade).trim();
+      const cgRegex = /^([0-9]{1,2}(th|st|nd|rd)?(\sGrade)?|Grade\s?[0-9]{1,2}|[A-Za-z0-9\s]+)$/i;
+      if (!cgRegex.test(cg)) {
+        return reply.status(400).send({ success: false, message: "Invalid class_grade format." });
+      }
+
+      // ensure authenticated parent
+      const user = (req as any).user;
+      if (!user || user.role !== "parent") {
+        return reply.status(403).send({ success: false, message: "Forbidden" });
+      }
+
+      const student = await parentService.addStudent(user.id, {
+        full_name: String(full_name).trim(),
+        class_grade: cg
+      });
+
+      return reply.status(201).send({
+        success: true,
+        message: "Student added successfully.",
+        data: {
+          id: student.id,
+          full_name: student.full_name,
+          class_grade: student.class_grade,
+          parent_id: student.parent_id,
+          created_at: student.createdAt
+        }
+      });
+    } catch (err: any) {
+      console.error("addStudent error:", err);
+      if (err.message && err.message.includes("Invalid parent id")) {
+        return reply.status(400).send({ success: false, message: "Invalid parent id." });
+      }
+      return reply.status(500).send({ success: false, message: "Internal Server Error" });
+    }
+  }
+
   //Admin panel
   async getParentRequests(req: FastifyRequest, reply: FastifyReply) {
     try {

--- a/src/models/Student.ts
+++ b/src/models/Student.ts
@@ -1,0 +1,22 @@
+import { Schema, model, Document, Types } from "mongoose";
+
+export interface IStudent extends Document {
+  full_name: string;
+  class_grade: string;
+  parent_id: Types.ObjectId;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const StudentSchema = new Schema<IStudent>(
+  {
+    full_name: { type: String, required: true },
+    class_grade: { type: String, required: true },
+    parent_id: { type: Schema.Types.ObjectId, ref: "User", required: true }
+  },
+  { timestamps: true }
+);
+
+StudentSchema.index({ parent_id: 1 });
+
+export default model<IStudent>("Student", StudentSchema);

--- a/src/routes/parent.routes.ts
+++ b/src/routes/parent.routes.ts
@@ -1,50 +1,93 @@
-import { FastifyInstance } from "fastify";
-import { ParentController } from "../controllers/parent.controller";
-import { authMiddleware, roleMiddleware } from "../middlewares/auth";
+import { FastifyInstance } from 'fastify';
+import { ParentController } from '../controllers/parent.controller';
+import { authMiddleware, roleMiddleware } from '../middlewares/auth';
 
 const parentController = new ParentController();
 
 export default async function parentRoutes(app: FastifyInstance) {
-  app.get("/parent/tutors", (req, reply) => parentController.getTutors(req, reply));
+  app.get('/parent/tutors', (req, reply) =>
+    parentController.getTutors(req, reply),
+  );
+
+  // Add student
+  app.post(
+    '/parent/add-student',
+    {
+      preHandler: [authMiddleware, roleMiddleware(['parent'])],
+      schema: {
+        tags: ['Parent'],
+        summary: 'Add a student to parent account',
+        consumes: ['application/json'],
+        body: {
+          type: 'object',
+          required: ['full_name', 'class_grade'],
+          properties: {
+            full_name: { type: 'string' },
+            class_grade: { type: 'string' },
+          },
+        },
+        response: {
+          201: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean' },
+              message: { type: 'string' },
+              data: { type: 'object' },
+            },
+          },
+          400: { type: 'object' },
+          403: { type: 'object' },
+        },
+      },
+    },
+    (req, reply) => parentController.addStudent(req, reply),
+  );
 
   // Admin: GET /parent/requests
   app.get(
-    "/parent/requests",
+    '/parent/requests',
     {
-      preHandler: [authMiddleware, roleMiddleware(["admin"])],
+      preHandler: [authMiddleware, roleMiddleware(['admin'])],
       schema: {
-        tags: ["Admin"],
-        summary: "Fetch parent-tutor requests (latest or all with filters)",
+        tags: ['Admin'],
+        summary: 'Fetch parent-tutor requests (latest or all with filters)',
         querystring: {
-          type: "object",
+          type: 'object',
           properties: {
-            type: { type: "string", enum: ["latest", "all"], default: "latest" },
-            status: { type: "string", enum: ["pending", "assigned", "completed", "cancelled"] },
-            subject: { type: "string" },
-            limit: { type: "integer", minimum: 1, default: 5 }
-          }
+            type: {
+              type: 'string',
+              enum: ['latest', 'all'],
+              default: 'latest',
+            },
+            status: {
+              type: 'string',
+              enum: ['pending', 'assigned', 'completed', 'cancelled'],
+            },
+            subject: { type: 'string' },
+            limit: { type: 'integer', minimum: 1, default: 5 },
+          },
         },
         response: {
           200: {
-            type: "array",
+            type: 'array',
             items: {
-              type: "object",
+              type: 'object',
               properties: {
-                id: { type: "string" },
-                parentId: { type: "string" },
-                parent: { type: "object", nullable: true },
-                academicNeeds: { type: "array", items: { type: "string" } },
-                scheduling: { type: "array", items: { type: "string" } },
-                location: { type: "string" },
-                urgency: { type: "string" },
-                status: { type: "string" },
-                createdAt: { type: "string", format: "date-time" }
-              }
-            }
-          }
-        }
-      }
+                id: { type: 'string' },
+                parentId: { type: 'string' },
+                parent: { type: 'object', nullable: true },
+                academicNeeds: { type: 'array', items: { type: 'string' } },
+                scheduling: { type: 'array', items: { type: 'string' } },
+                location: { type: 'string' },
+                urgency: { type: 'string' },
+                status: { type: 'string' },
+                createdAt: { type: 'string', format: 'date-time' },
+              },
+            },
+          },
+        },
+      },
     },
-    (req, reply) => parentController.getParentRequests(req, reply)
+    (req, reply) => parentController.getParentRequests(req, reply),
   );
 }

--- a/src/services/parent.service.ts
+++ b/src/services/parent.service.ts
@@ -1,5 +1,7 @@
 import User from "../models/User";
 import ParentRequest from "../models/ParentRequest";
+import Student from "../models/Student";
+import { Types } from "mongoose";
 
 export class ParentService {
   async searchTutors(filters: any) {
@@ -109,5 +111,25 @@ export class ParentService {
       status: r.status,
       createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : new Date(r.createdAt).toISOString()
     }));
+  }
+
+
+  // add student
+  async addStudent(parentId: string, payload: { full_name: string; class_grade: string }) {
+    if (!payload.full_name || !payload.class_grade) {
+      throw new Error("Missing required fields");
+    }
+
+    if (!Types.ObjectId.isValid(parentId)) {
+      throw new Error("Invalid parent id");
+    }
+
+    const student = await Student.create({
+      full_name: payload.full_name,
+      class_grade: payload.class_grade,
+      parent_id: new Types.ObjectId(parentId)
+    });
+
+    return student;
   }
 }


### PR DESCRIPTION
Implemented the POST /parent/add-student API endpoint to allow authenticated parents to add a new student to their account.
This feature validates required fields (full_name, class_grade), links the student with the parent’s profile, and returns the student’s details upon successful creation.
Includes proper error handling for missing fields and unauthorized access.