### PR TITLE
27-get-upcoming-and-completed-assignments-quizzes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import authRoutes from "./routes/auth.routes";
 import parentRoutes from "./routes/parent.routes";
+import studentRoutes from "./routes/student.routes";
 import multipart from "@fastify/multipart";
 import fastifyStatic from "@fastify/static";
 import path from "path";
@@ -67,6 +68,7 @@ async function buildApp() {
   app.register(authRoutes, { prefix: "/api/v1" });
   app.register(parentRoutes, { prefix: "/api/v1" });
   app.register(tutorRoutes, { prefix: "/api/v1" });
+  app.register(studentRoutes, { prefix: "/api/v1" });
 
   return app;
 }

--- a/src/controllers/student.controller.ts
+++ b/src/controllers/student.controller.ts
@@ -1,0 +1,41 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+import StudentService from "../services/student.service";
+
+export class StudentController {
+  async getAssignmentsQuizzes(req: FastifyRequest, reply: FastifyReply) {
+    try {
+      const user = (req as any).user;
+      if (!user || user.role !== "student") {
+        return reply.status(403).send({ success: false, message: "Forbidden" });
+      }
+
+      // read query params
+      const status = (req.query as any).status; // optional
+      const page = Number((req.query as any).page) || 1;
+      const limit = Number((req.query as any).limit) || 10;
+
+      const classGrade = (user.class_grade as string) || (req.query as any).class_grade;
+      if (!classGrade) {
+        return reply.status(200).send({
+          success: true,
+          data: { upcoming: [], completed: [] },
+          summary: { upcoming_count: 0, completed_count: 0 }
+        });
+      }
+
+      const result = await StudentService.fetchAssignmentsAndQuizzes({
+        classGrade,
+        status,
+        page,
+        limit
+      });
+
+      return reply.status(200).send({ success: true, data: { upcoming: result.upcoming, completed: result.completed }, summary: result.summary });
+    } catch (err: any) {
+      console.error("getAssignmentsQuizzes error:", err);
+      return reply.status(500).send({ success: false, message: "Internal Server Error" });
+    }
+  }
+}
+
+export default new StudentController();

--- a/src/routes/student.routes.ts
+++ b/src/routes/student.routes.ts
@@ -1,0 +1,30 @@
+import { FastifyInstance } from "fastify";
+import StudentController from "../controllers/student.controller";
+import { authMiddleware, roleMiddleware } from "../middlewares/auth";
+
+export default async function studentRoutes(app: FastifyInstance) {
+  app.get(
+    "/student/assignments-quizzes",
+    {
+      preHandler: [authMiddleware, roleMiddleware(["student"])],
+      schema: {
+        tags: ["Student"],
+        summary: "Get student's upcoming and completed assignments & quizzes",
+        querystring: {
+          type: "object",
+          properties: {
+            status: { type: "string", enum: ["upcoming", "completed"] },
+            page: { type: "integer", minimum: 1, default: 1 },
+            limit: { type: "integer", minimum: 1, default: 10 }
+          }
+        },
+        response: {
+          200: {
+            type: "object"
+          }
+        }
+      }
+    },
+    (req, reply) => StudentController.getAssignmentsQuizzes(req, reply)
+  );
+}

--- a/src/services/student.service.ts
+++ b/src/services/student.service.ts
@@ -1,0 +1,128 @@
+import Assignment from "../models/Assignment";
+import Quiz from "../models/Quiz";
+import { Types } from "mongoose";
+
+export class StudentService {
+  async fetchAssignmentsAndQuizzes(options: {
+    classGrade: string;
+    status?: string;
+    page?: number;
+    limit?: number;
+  }) {
+    const { classGrade, status, page = 1, limit = 10 } = options;
+    const pageNum = Math.max(1, Number(page) || 1);
+    const limitNum = Math.max(1, Number(limit) || 10);
+    const skip = (pageNum - 1) * limitNum;
+
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()); // midnight today
+
+    const isUpcomingMatch = (docDueDate: string | undefined) => {
+      if (!docDueDate) return true;
+      const d = new Date(docDueDate + "T23:59:59Z");
+      return d >= today;
+    };
+
+    const assignmentBaseQuery: any = { class_grade: classGrade };
+
+    const quizBaseQuery: any = { class_grade: classGrade };
+
+    // Adjust queries for status
+    let assignmentQuery = { ...assignmentBaseQuery };
+    let quizQuery = { ...quizBaseQuery };
+
+    if (status === "upcoming") {
+      const isoToday = today.toISOString().slice(0, 10); // YYYY-MM-DD
+      assignmentQuery = {
+        ...assignmentBaseQuery,
+        $or: [{ due_date: { $gte: isoToday } }, { due_date: { $exists: false } }]
+      };
+      quizQuery = {
+        ...quizBaseQuery,
+        $or: [{ due_date: { $gte: isoToday } }, { due_date: { $exists: false } }]
+      };
+    } else if (status === "completed") {
+      const isoToday = today.toISOString().slice(0, 10);
+      assignmentQuery = {
+        ...assignmentBaseQuery,
+        due_date: { $lt: isoToday }
+      };
+      quizQuery = {
+        ...quizBaseQuery,
+        due_date: { $lt: isoToday }
+      };
+    }
+
+    const [assignments, quizzes] = await Promise.all([
+      Assignment.find(assignmentQuery)
+        .sort(status === "completed" ? { due_date: -1 } : { due_date: 1 })
+        .skip(skip)
+        .limit(limitNum)
+        .populate({ path: "created_by", select: "fullName" })
+        .lean(),
+      Quiz.find(quizQuery)
+        .sort(status === "completed" ? { createdAt: -1 } : { createdAt: 1 })
+        .skip(skip)
+        .limit(limitNum)
+        .populate({ path: "created_by", select: "fullName" })
+        .lean()
+    ]);
+
+    // Map to unified shape
+    const mapAssignment = (a: any) => {
+      const due_date = a.due_date || a.createdAt?.toISOString?.().slice(0, 10) || null;
+      const isCompleted = a.due_date ? new Date(a.due_date + "T23:59:59Z") < today : false;
+      return {
+        id: String(a._id),
+        title: a.title,
+        subject: a.subject,
+        tutor: a.created_by?.fullName || "",
+        due_date,
+        type: "Assignment",
+        completed_on: isCompleted ? a.updatedAt || a.due_date : undefined
+      };
+    };
+
+    const mapQuiz = (q: any) => {
+      const due_date = q.due_date || q.createdAt?.toISOString?.().slice(0, 10) || null;
+      const isCompleted = q.due_date ? new Date(q.due_date + "T23:59:59Z") < today : false;
+      return {
+        id: String(q._id),
+        title: q.title,
+        subject: q.subject,
+        tutor: q.created_by?.fullName || "",
+        due_date,
+        type: "Quiz",
+        completed_on: isCompleted ? q.updatedAt || q.due_date : undefined
+      };
+    };
+
+    // Separate upcoming & completed lists
+    const allItems = [
+      ...assignments.map(mapAssignment),
+      ...quizzes.map(mapQuiz)
+    ];
+
+    const upcoming = allItems.filter((it) => {
+      // upcoming if due_date is null (no due) OR due_date >= today
+      if (!it.due_date) return true;
+      const d = new Date(it.due_date + "T23:59:59Z");
+      return d >= today;
+    });
+
+    const completed = allItems.filter((it) => {
+      if (!it.due_date) return false;
+      const d = new Date(it.due_date + "T23:59:59Z");
+      return d < today;
+    });
+
+    const summary = {
+      upcoming_count: upcoming.length,
+      completed_count: completed.length
+    };
+
+    return { upcoming, completed, summary };
+  }
+}
+
+export default new StudentService();


### PR DESCRIPTION
This PR adds an endpoint for students to fetch their upcoming and completed assignments/quizzes with filtering and pagination support.

Features:
Added GET /student/assignments-quizzes endpoint
Supports status, page, and limit query parameters
Returns categorized lists (upcoming & completed) with title, subject, tutor, due_date, and type
Includes authentication check and summary response