### PR TITLE
31-get-all-quizzes-created-by-tutor1

### DIFF
--- a/src/routes/tutor.routes.ts
+++ b/src/routes/tutor.routes.ts
@@ -240,4 +240,57 @@ export default async function tutorRoutes(app: FastifyInstance) {
     },
     (req, reply) => tutorController.uploadStudyMaterial(req, reply)
   );
+
+
+    // Get all quizzes created by tutor
+  app.get(
+    "/tutor/quizzes", // or "/tutor/quizzes/" if you want trailing slash
+    {
+      preHandler: [authMiddleware, roleMiddleware(["tutor"])],
+      schema: {
+        tags: ["Tutor"],
+        summary: "Get all quizzes created by tutor",
+        querystring: {
+          type: "object",
+          properties: {
+            subject: { type: "string" },
+            class_grade: { type: "string" },
+            page: { type: "number" },
+            limit: { type: "number" }
+          }
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              success: { type: "boolean" },
+              data: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    title: { type: "string" },
+                    subject: { type: "string" },
+                    class_grade: { type: "string" },
+                    due_date: { type: ["string", "null"] },
+                    total_questions: { type: "number" },
+                    status: { type: "string" }
+                  }
+                }
+              }
+            }
+          },
+          404: {
+            type: "object",
+            properties: {
+              success: { type: "boolean" },
+              message: { type: "string" }
+            }
+          }
+        }
+      }
+    },
+    (req, reply) => tutorController.getTutorQuizzes(req, reply)
+  );
 }

--- a/src/services/tutor.service.ts
+++ b/src/services/tutor.service.ts
@@ -309,4 +309,45 @@ export class TutorService {
 
     return doc;
   }
+
+    // Get tutor quizzes with filtering and pagination
+  async getTutorQuizzes(
+    tutorId: string,
+    filters: {
+      subject?: string;
+      class_grade?: string;
+      page?: number;
+      limit?: number;
+    }
+  ) {
+    const page = Math.max(1, filters.page || 1);
+    const limit = Math.max(1, Math.min(100, filters.limit || 10)); // default 10, max 100
+    const skip = (page - 1) * limit;
+
+    // Build query - only quizzes created by this tutor
+    const query: any = { created_by: tutorId };
+
+    if (filters.subject) {
+      query.subject = filters.subject;
+    }
+
+    if (filters.class_grade) {
+      query.class_grade = filters.class_grade;
+    }
+
+    // Get quizzes with pagination
+    const [quizzes, total] = await Promise.all([
+      Quiz.find(query)
+        .sort({ createdAt: -1 }) // newest first
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Quiz.countDocuments(query),
+    ]);
+
+    return {
+      quizzes,
+      total,
+    };
+  }
 }


### PR DESCRIPTION
It adds a new API endpoint that allows tutors to fetch all quizzes they have created. The feature supports filtering and pagination to make quiz management easier.
-Added GET /tutor/quizzes/ endpoint for authenticated tutors.
-Returns all quizzes created by the logged-in tutor.
-Supports filtering by subject and class_grade.
-Added pagination with page and limit query params.
-Response includes quiz metadata: title, subject, class, due date, total questions & status.
-Returns proper error handling when no quizzes are found.