### PR TITLE
32 get all assignments created by tutor

### DIFF
--- a/src/controllers/tutor.controller.ts
+++ b/src/controllers/tutor.controller.ts
@@ -689,5 +689,71 @@ export class TutorController {
     }
   }
 
+
+  // Get tutor assignments
+  async getTutorAssignments(req: FastifyRequest, reply: FastifyReply) {
+    try {
+      const user = (req as any).user;
+      if (!user || user.role !== 'tutor') {
+        return reply.status(403).send({
+          success: false,
+          message: 'Forbidden',
+        });
+      }
+
+      const query = req.query as any;
+      const subject = query.subject?.trim();
+      const class_grade = query.class_grade?.trim();
+      const page = query.page ? Number(query.page) : 1;
+      const limit = query.limit ? Number(query.limit) : 10;
+
+      const result = await tutorService.getTutorAssignments(user.id, {
+        subject,
+        class_grade,
+        page,
+        limit,
+      });
+
+      // If no assignments, return 404 as per spec
+      if (!result.assignments || result.assignments.length === 0) {
+        return reply.status(404).send({
+          success: false,
+          message: 'No assignments found for this tutor.',
+        });
+      }
+
+      // Compute status based on due_date (simple example: Active / Past Due)
+      const today = new Date().toISOString().slice(0, 10); // 'YYYY-MM-DD'
+
+      const formattedAssignments = result.assignments.map((assignment: any) => {
+        const status =
+          assignment.due_date && assignment.due_date >= today
+            ? 'Active'
+            : 'Past Due';
+
+        return {
+          id: String(assignment._id),
+          title: assignment.title,
+          subject: assignment.subject,
+          class_grade: assignment.class_grade,
+          due_date: assignment.due_date,
+          allow_submission_online: assignment.allow_submission_online,
+          status,
+        };
+      });
+
+      return reply.status(200).send({
+        success: true,
+        data: formattedAssignments,
+      });
+    } catch (err: any) {
+      console.error('getTutorAssignments error:', err);
+      return reply.status(500).send({
+        success: false,
+        message: 'Internal Server Error',
+      });
+    }
+  }
+
   
 }

--- a/src/routes/tutor.routes.ts
+++ b/src/routes/tutor.routes.ts
@@ -240,4 +240,57 @@ export default async function tutorRoutes(app: FastifyInstance) {
     },
     (req, reply) => tutorController.uploadStudyMaterial(req, reply)
   );
+
+
+    // Get all quizzes created by tutor
+  app.get(
+    "/tutor/quizzes", // or "/tutor/quizzes/" if you want trailing slash
+    {
+      preHandler: [authMiddleware, roleMiddleware(["tutor"])],
+      schema: {
+        tags: ["Tutor"],
+        summary: "Get all quizzes created by tutor",
+        querystring: {
+          type: "object",
+          properties: {
+            subject: { type: "string" },
+            class_grade: { type: "string" },
+            page: { type: "number" },
+            limit: { type: "number" }
+          }
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              success: { type: "boolean" },
+              data: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    title: { type: "string" },
+                    subject: { type: "string" },
+                    class_grade: { type: "string" },
+                    due_date: { type: ["string", "null"] },
+                    total_questions: { type: "number" },
+                    status: { type: "string" }
+                  }
+                }
+              }
+            }
+          },
+          404: {
+            type: "object",
+            properties: {
+              success: { type: "boolean" },
+              message: { type: "string" }
+            }
+          }
+        }
+      }
+    },
+    (req, reply) => tutorController.getTutorQuizzes(req, reply)
+  );
 }

--- a/src/routes/tutor.routes.ts
+++ b/src/routes/tutor.routes.ts
@@ -293,4 +293,58 @@ export default async function tutorRoutes(app: FastifyInstance) {
     },
     (req, reply) => tutorController.getTutorQuizzes(req, reply)
   );
+
+
+  // Get all assignments created by tutor
+  app.get(
+    "/tutor/assignments",
+    {
+      preHandler: [authMiddleware, roleMiddleware(["tutor"])],
+      schema: {
+        tags: ["Tutor"],
+        summary: "Get all assignments created by tutor",
+        querystring: {
+          type: "object",
+          properties: {
+            subject: { type: "string" },
+            class_grade: { type: "string" },
+            page: { type: "number" },
+            limit: { type: "number" }
+          }
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              success: { type: "boolean" },
+              data: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    title: { type: "string" },
+                    subject: { type: "string" },
+                    class_grade: { type: "string" },
+                    due_date: { type: "string" },
+                    allow_submission_online: { type: "boolean" },
+                    status: { type: "string" }
+                  }
+                }
+              }
+            }
+          },
+          404: {
+            type: "object",
+            properties: {
+              success: { type: "boolean" },
+              message: { type: "string" }
+            }
+          }
+        }
+      }
+    },
+    (req, reply) => tutorController.getTutorAssignments(req, reply)
+  );
+
 }

--- a/src/services/tutor.service.ts
+++ b/src/services/tutor.service.ts
@@ -309,4 +309,45 @@ export class TutorService {
 
     return doc;
   }
+
+    // Get tutor quizzes with filtering and pagination
+  async getTutorQuizzes(
+    tutorId: string,
+    filters: {
+      subject?: string;
+      class_grade?: string;
+      page?: number;
+      limit?: number;
+    }
+  ) {
+    const page = Math.max(1, filters.page || 1);
+    const limit = Math.max(1, Math.min(100, filters.limit || 10)); // default 10, max 100
+    const skip = (page - 1) * limit;
+
+    // Build query - only quizzes created by this tutor
+    const query: any = { created_by: tutorId };
+
+    if (filters.subject) {
+      query.subject = filters.subject;
+    }
+
+    if (filters.class_grade) {
+      query.class_grade = filters.class_grade;
+    }
+
+    // Get quizzes with pagination
+    const [quizzes, total] = await Promise.all([
+      Quiz.find(query)
+        .sort({ createdAt: -1 }) // newest first
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Quiz.countDocuments(query),
+    ]);
+
+    return {
+      quizzes,
+      total,
+    };
+  }
 }

--- a/src/services/tutor.service.ts
+++ b/src/services/tutor.service.ts
@@ -350,4 +350,46 @@ export class TutorService {
       total,
     };
   }
+
+
+  // Get tutor assignments with filtering and pagination
+  async getTutorAssignments(
+    tutorId: string,
+    filters: {
+      subject?: string;
+      class_grade?: string;
+      page?: number;
+      limit?: number;
+    }
+  ) {
+    const page = Math.max(1, filters.page || 1);
+    const limit = Math.max(1, Math.min(100, filters.limit || 10)); // default 10, max 100
+    const skip = (page - 1) * limit;
+
+    // Only assignments created by this tutor
+    const query: any = { created_by: tutorId };
+
+    if (filters.subject) {
+      query.subject = filters.subject;
+    }
+
+    if (filters.class_grade) {
+      query.class_grade = filters.class_grade;
+    }
+
+    const [assignments, total] = await Promise.all([
+      Assignment.find(query)
+        .sort({ createdAt: -1 }) // newest first
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Assignment.countDocuments(query),
+    ]);
+
+    return {
+      assignments,
+      total,
+    };
+  }
+
 }


### PR DESCRIPTION
**Summary:**
Implements GET /tutor/assignments so authenticated tutors can list all assignments they’ve created. Adds filters for subject/class, basic pagination, and returns empty-state messaging per product spec.
**Changes:**
Added TutorService.getTutorAssignments to query assignments by tutor with optional filters and pagination.
Added TutorController.getTutorAssignments to handle auth, query parsing, empty-state handling, and response formatting (title, subject, class, due date, submission flag, status).
Registered new Fastify route /tutor/assignments with schema definitions and tutor-only guards.
**Testing:**
GET /tutor/assignments (no filters) with valid tutor token → returns list of assignments created by that tutor.
GET /tutor/assignments?subject=Math&class_grade=9th Grade&page=2&limit=5 → respects filters & pagination.
GET /tutor/assignments when tutor has no assignments → 404 with No assignments found for this tutor.